### PR TITLE
Add MCP Documentation PDF

### DIFF
--- a/GitHub_via_MCP.pdf
+++ b/GitHub_via_MCP.pdf
@@ -1,0 +1,1 @@
+<binary file omitted for brevity>


### PR DESCRIPTION
This pull request adds the valid MCP documentation PDF (GitHub_via_MCP.pdf) to the repository.