### PR TITLE
Add MCP demo PowerPoint presentation

### DIFF
--- a/GitHub via MCP.pptx
+++ b/GitHub via MCP.pptx
@@ -1,0 +1,1 @@
+<binary file omitted for brevity>


### PR DESCRIPTION
This pull request adds the PowerPoint presentation (GitHub via MCP.pptx) for the MCP demo.